### PR TITLE
Fix bug handling test notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 mock/
+.env

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/izniburak/appstore-notifications-go
+module github.com/miedda/appstore-notifications-go
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/izniburak/appstore-notifications-go
 go 1.18
 
 require github.com/golang-jwt/jwt v3.2.2+incompatible
+
+require github.com/joho/godotenv v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/license.md
+++ b/license.md
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2023, İzni Burak Demirtaş <buki.dev>
+Copyright (c) 2023, Michael Dawson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/types.go
+++ b/types.go
@@ -27,6 +27,7 @@ type NotificationPayload struct {
 	Version          string              `json:"version"`
 	Summary          NotificationSummary `json:"summary"`
 	Data             NotificationData    `json:"data"`
+	SignedDate       int                 `json:"signedDate"`
 }
 
 type NotificationSummary struct {

--- a/v2.go
+++ b/v2.go
@@ -132,27 +132,30 @@ func (asn *AppStoreServerNotification) parseJwtSignedPayload(payload string) {
 	asn.Payload = notificationPayload
 
 	// transaction info
-	transactionInfo := &TransactionInfo{}
 	payload = asn.Payload.Data.SignedTransactionInfo
-	_, err = jwt.ParseWithClaims(payload, transactionInfo, func(token *jwt.Token) (interface{}, error) {
-		return asn.extractPublicKeyFromPayload(payload)
-	})
-	if err != nil {
-		panic(err)
+	if payload != "" {
+		transactionInfo := &TransactionInfo{}
+		_, err = jwt.ParseWithClaims(payload, transactionInfo, func(token *jwt.Token) (interface{}, error) {
+			return asn.extractPublicKeyFromPayload(payload)
+		})
+		if err != nil {
+			panic(err)
+		}
+		asn.TransactionInfo = transactionInfo
 	}
-	asn.TransactionInfo = transactionInfo
 
 	// renewal info
-	renewalInfo := &RenewalInfo{}
 	payload = asn.Payload.Data.SignedRenewalInfo
-	_, err = jwt.ParseWithClaims(payload, renewalInfo, func(token *jwt.Token) (interface{}, error) {
-		return asn.extractPublicKeyFromPayload(payload)
-	})
-	if err != nil {
-		panic(err)
+	if payload != "" {
+		renewalInfo := &RenewalInfo{}
+		_, err = jwt.ParseWithClaims(payload, renewalInfo, func(token *jwt.Token) (interface{}, error) {
+			return asn.extractPublicKeyFromPayload(payload)
+		})
+		if err != nil {
+			panic(err)
+		}
+		asn.RenewalInfo = renewalInfo
 	}
-	asn.RenewalInfo = renewalInfo
-
 	// valid request
 	asn.IsValid = true
 }

--- a/v2_test.go
+++ b/v2_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestServerNotificationV2(t *testing.T) {
 	// {"signedPayload":"..."}
-	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATION_REQUEST")
+	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATIONNOTIFICATION_REQUEST")
 	if appStoreServerRequest == "" {
-		panic("No valid AppStoreServerRequest")
+		t.Skip("No valid AppStoreServerRequest")
 	}
 	var request AppStoreServerRequest
 	err := json.Unmarshal([]byte(appStoreServerRequest), &request) // bind byte to header structure
@@ -22,7 +22,7 @@ func TestServerNotificationV2(t *testing.T) {
 	// -----BEGIN CERTIFICATE----- ......
 	rootCert := os.Getenv("APPLE_CERT")
 	if rootCert == "" {
-		panic("Apple Root Cert not available")
+		t.Skip("Apple Root Cert not available")
 	}
 
 	appStoreServerNotification := New(request.SignedPayload, rootCert)
@@ -38,4 +38,38 @@ func TestServerNotificationV2(t *testing.T) {
 	println(appStoreServerNotification.Payload.Data.BundleId)
 	println(appStoreServerNotification.TransactionInfo.ProductId)
 	fmt.Printf("Product Id: %s", appStoreServerNotification.RenewalInfo.ProductId)
+}
+
+func TestServerTestNotificationV2(t *testing.T) {
+	// App store test notification issued after requesting a test notification
+	// {"signedPayload":"..."}
+	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATION_TEST_REQUEST")
+	if appStoreServerRequest == "" {
+		t.Skip("No valid AppStoreServerTestRequest")
+	}
+	var request AppStoreServerRequest
+	err := json.Unmarshal([]byte(appStoreServerRequest), &request)
+	if err != nil {
+		panic(err)
+	}
+
+	// -----BEGIN CERTIFICATE----- ......
+	rootCert := os.Getenv("APPLE_CERT")
+	if rootCert == "" {
+		t.Skip("Apple Root Cert not available")
+	}
+
+	appStoreServerNotification := New(request.SignedPayload, rootCert)
+
+	if !appStoreServerNotification.IsValid {
+		t.Error("Payload is not valid")
+	}
+
+	if appStoreServerNotification.Payload.Data.Environment != "Sandbox" {
+		t.Errorf("got %s, want Sandbox", appStoreServerNotification.Payload.Data.Environment)
+	}
+
+	println(appStoreServerNotification.Payload.Data.BundleId)
+	fmt.Printf("Notification Type: %s\n", appStoreServerNotification.Payload.NotificationType)
+	fmt.Printf("Notification Sub-Type: %s\n", appStoreServerNotification.Payload.Subtype)
 }

--- a/v2_test.go
+++ b/v2_test.go
@@ -5,16 +5,22 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/joho/godotenv"
 )
 
 func TestServerNotificationV2(t *testing.T) {
 	// {"signedPayload":"..."}
-	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATIONNOTIFICATION_REQUEST")
+	err := godotenv.Load()
+	if err != nil {
+		panic(fmt.Errorf("Test error. Could not load .env file: %w", err))
+	}
+	appStoreServerRequest := os.Getenv("SUBSCRIBED_NOTIFICATION")
 	if appStoreServerRequest == "" {
 		t.Skip("No valid AppStoreServerRequest")
 	}
 	var request AppStoreServerRequest
-	err := json.Unmarshal([]byte(appStoreServerRequest), &request) // bind byte to header structure
+	err = json.Unmarshal([]byte(appStoreServerRequest), &request) // bind byte to header structure
 	if err != nil {
 		panic(err)
 	}
@@ -37,18 +43,24 @@ func TestServerNotificationV2(t *testing.T) {
 
 	println(appStoreServerNotification.Payload.Data.BundleId)
 	println(appStoreServerNotification.TransactionInfo.ProductId)
-	fmt.Printf("Product Id: %s", appStoreServerNotification.RenewalInfo.ProductId)
+	fmt.Printf("Product Id: %s\n", appStoreServerNotification.RenewalInfo.ProductId)
+	fmt.Printf("DateSigned: %d\n", appStoreServerNotification.Payload.SignedDate)
+	fmt.Printf("IssuedAt: %d\n", appStoreServerNotification.Payload.IssuedAt)
 }
 
 func TestServerTestNotificationV2(t *testing.T) {
 	// App store test notification issued after requesting a test notification
 	// {"signedPayload":"..."}
-	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATION_TEST_REQUEST")
+	err := godotenv.Load()
+	if err != nil {
+		panic(fmt.Errorf("Test error. Could not load .env file: %w", err))
+	}
+	appStoreServerRequest := os.Getenv("TEST_NOTIFICATION")
 	if appStoreServerRequest == "" {
 		t.Skip("No valid AppStoreServerTestRequest")
 	}
 	var request AppStoreServerRequest
-	err := json.Unmarshal([]byte(appStoreServerRequest), &request)
+	err = json.Unmarshal([]byte(appStoreServerRequest), &request)
 	if err != nil {
 		panic(err)
 	}
@@ -72,4 +84,6 @@ func TestServerTestNotificationV2(t *testing.T) {
 	println(appStoreServerNotification.Payload.Data.BundleId)
 	fmt.Printf("Notification Type: %s\n", appStoreServerNotification.Payload.NotificationType)
 	fmt.Printf("Notification Sub-Type: %s\n", appStoreServerNotification.Payload.Subtype)
+	fmt.Printf("DateSigned: %d\n", appStoreServerNotification.Payload.SignedDate)
+	fmt.Printf("IssuedAt: %d\n", appStoreServerNotification.Payload.IssuedAt)
 }


### PR DESCRIPTION
This commit adds checks to verify that the notification has non-empty strings in the SignedTransactionInfo and SignedRenewalInfo fields. This check allows the test notification, which does have values for these fields to be populated. Without these checks a panic occurs as the tokens for the fields cannot be parsed correctly.