### PR TITLE
fix: return errors instead of panicking, handle optional inner JWTs, upgrade golang-jwt to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/izniburak/appstore-notifications-go
 
-go 1.18
+go 1.21
 
-require github.com/golang-jwt/jwt v3.2.2+incompatible
+require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/readme.md
+++ b/readme.md
@@ -40,9 +40,14 @@ func main() {
 		panic("Apple Root Cert not valid")
 	}
 
-	appStoreServerNotification := appstore.New(request.SignedPayload, rootCert)
-	fmt.Printf("App Store Server Notification is valid?: %t\n", appStoreServerNotification.IsValid)
-	fmt.Printf("Product Id: %s\n", appStoreServerNotification.TransactionInfo.ProductId)
+	asn, err := appstore.New(request.SignedPayload, rootCert)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("App Store Server Notification is valid?: %t\n", asn.IsValid)
+	if asn.TransactionInfo != nil {
+		fmt.Printf("Product Id: %s\n", asn.TransactionInfo.ProductId)
+	}
 }
 ```
 You can access the all data in the payload by using one of the 4 params in instance of the `AppStoreServerNotification`:
@@ -51,6 +56,9 @@ You can access the all data in the payload by using one of the 4 params in insta
 - _instance_***.TransactionInfo***: Access the [Transaction Info](https://developer.apple.com/documentation/appstoreservernotifications/jwstransactiondecodedpayload).
 - _instance_***.RenewalInfo***: Access the [Renewal Info](https://developer.apple.com/documentation/appstoreservernotifications/jwsrenewalinfodecodedpayload).
 - _instance_***.IsValid***: Check the payload parsed and verified successfully.
+- _instance_***.IsTest***: True when `notificationType` is `TEST`. In this case `TransactionInfo` and `RenewalInfo` will be `nil`.
+
+`New` returns an error for any malformed or unexpected payload (invalid JWT, short `x5c` chain, certificate verification failure, etc.). `TransactionInfo` and `RenewalInfo` are `nil` for notification types that don't carry signed inner JWTs (e.g. `TEST`, `EXTERNAL_PURCHASE_TOKEN`, `RENEWAL_EXTENDED`).
 
 ## Contributing
 

--- a/types.go
+++ b/types.go
@@ -1,6 +1,6 @@
 package v2
 
-import "github.com/golang-jwt/jwt"
+import "github.com/golang-jwt/jwt/v5"
 
 type AppStoreServerNotification struct {
 	appleRootCert   string
@@ -21,7 +21,7 @@ type NotificationHeader struct {
 }
 
 type NotificationPayload struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	NotificationType      string                `json:"notificationType"`
 	Subtype               string                `json:"subtype"`
 	NotificationUUID      string                `json:"notificationUUID"`
@@ -62,7 +62,7 @@ type NotificationData struct {
 }
 
 type TransactionInfo struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	AppAccountToken             string `json:"appAccountToken"`
 	BundleId                    string `json:"bundleId"`
 	Currency                    string `json:"currency,omitempty"`
@@ -92,7 +92,7 @@ type TransactionInfo struct {
 }
 
 type RenewalInfo struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	AutoRenewProductId          string `json:"autoRenewProductId"`
 	AutoRenewStatus             int32  `json:"autoRenewStatus"`
 	Environment                 string `json:"environment"`

--- a/v2.go
+++ b/v2.go
@@ -6,38 +6,43 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
-func New(payload string, appleRootCert string) *AppStoreServerNotification {
+func New(payload string, appleRootCert string) (*AppStoreServerNotification, error) {
 	asn := &AppStoreServerNotification{}
 	asn.IsValid = false
 	asn.IsTest = false
 	asn.appleRootCert = appleRootCert
-	asn.parseJwtSignedPayload(payload)
-	return asn
+	if err := asn.parseJwtSignedPayload(payload); err != nil {
+		return asn, err
+	}
+	return asn, nil
 }
 
 func (asn *AppStoreServerNotification) extractHeaderByIndex(payload string, index int) ([]byte, error) {
-	// get header from token
 	payloadArr := strings.Split(payload, ".")
+	if len(payloadArr) < 3 {
+		return nil, errors.New("payload must be a valid JWS token with 3 segments")
+	}
 
-	// convert header to byte
 	headerByte, err := base64.RawStdEncoding.DecodeString(payloadArr[0])
 	if err != nil {
 		return nil, err
 	}
 
-	// bind byte to header structure
 	var header NotificationHeader
-	err = json.Unmarshal(headerByte, &header)
-	if err != nil {
+	if err = json.Unmarshal(headerByte, &header); err != nil {
 		return nil, err
 	}
 
-	// decode x.509 certificate headers to byte
+	if len(header.X5c) <= index {
+		return nil, fmt.Errorf("x5c header has %d entries, need at least %d", len(header.X5c), index+1)
+	}
+
 	certByte, err := base64.StdEncoding.DecodeString(header.X5c[index])
 	if err != nil {
 		return nil, err
@@ -47,16 +52,13 @@ func (asn *AppStoreServerNotification) extractHeaderByIndex(payload string, inde
 }
 
 func (asn *AppStoreServerNotification) verifyCertificate(certByte []byte, intermediateCert []byte) error {
-	// create certificate pool
 	roots := x509.NewCertPool()
 
-	// parse and append apple root certificate to the pool
 	ok := roots.AppendCertsFromPEM([]byte(asn.appleRootCert))
 	if !ok {
 		return errors.New("root certificate couldn't be parsed")
 	}
 
-	// parse and append intermediate x5c certificate
 	interCert, err := x509.ParseCertificate(intermediateCert)
 	if err != nil {
 		return errors.New("intermediate certificate couldn't be parsed")
@@ -64,13 +66,11 @@ func (asn *AppStoreServerNotification) verifyCertificate(certByte []byte, interm
 	intermediate := x509.NewCertPool()
 	intermediate.AddCert(interCert)
 
-	// parse x5c certificate
 	cert, err := x509.ParseCertificate(certByte)
 	if err != nil {
 		return err
 	}
 
-	// verify X5c certificate using app store certificate resides in opts
 	opts := x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: intermediate,
@@ -83,19 +83,16 @@ func (asn *AppStoreServerNotification) verifyCertificate(certByte []byte, interm
 }
 
 func (asn *AppStoreServerNotification) extractPublicKeyFromPayload(payload string) (*ecdsa.PublicKey, error) {
-	// get certificate from X5c[0] header
 	certStr, err := asn.extractHeaderByIndex(payload, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	// parse certificate
 	cert, err := x509.ParseCertificate(certStr)
 	if err != nil {
 		return nil, err
 	}
 
-	// get public key
 	switch pk := cert.PublicKey.(type) {
 	case *ecdsa.PublicKey:
 		return pk, nil
@@ -104,62 +101,53 @@ func (asn *AppStoreServerNotification) extractPublicKeyFromPayload(payload strin
 	}
 }
 
-func (asn *AppStoreServerNotification) parseJwtSignedPayload(payload string) {
-	// get root certificate from x5c header
+func (asn *AppStoreServerNotification) parseJwtSignedPayload(payload string) error {
 	rootCertStr, err := asn.extractHeaderByIndex(payload, 2)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	// get intermediate certificate from x5c header
 	intermediateCertStr, err := asn.extractHeaderByIndex(payload, 1)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	// verify certificates
 	if err = asn.verifyCertificate(rootCertStr, intermediateCertStr); err != nil {
-		panic(err)
+		return err
 	}
 
-	// payload data
 	notificationPayload := &NotificationPayload{}
 	_, err = jwt.ParseWithClaims(payload, notificationPayload, func(token *jwt.Token) (interface{}, error) {
 		return asn.extractPublicKeyFromPayload(payload)
 	})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	asn.Payload = notificationPayload
 	asn.IsTest = asn.Payload.NotificationType == "TEST"
 
-	if asn.IsTest {
-		asn.IsValid = true
-		return
+	if sti := asn.Payload.Data.SignedTransactionInfo; sti != "" {
+		transactionInfo := &TransactionInfo{}
+		_, err = jwt.ParseWithClaims(sti, transactionInfo, func(token *jwt.Token) (interface{}, error) {
+			return asn.extractPublicKeyFromPayload(sti)
+		})
+		if err != nil {
+			return fmt.Errorf("parse signedTransactionInfo: %w", err)
+		}
+		asn.TransactionInfo = transactionInfo
 	}
 
-	// transaction info
-	transactionInfo := &TransactionInfo{}
-	payload = asn.Payload.Data.SignedTransactionInfo
-	_, err = jwt.ParseWithClaims(payload, transactionInfo, func(token *jwt.Token) (interface{}, error) {
-		return asn.extractPublicKeyFromPayload(payload)
-	})
-	if err != nil {
-		panic(err)
+	if sri := asn.Payload.Data.SignedRenewalInfo; sri != "" {
+		renewalInfo := &RenewalInfo{}
+		_, err = jwt.ParseWithClaims(sri, renewalInfo, func(token *jwt.Token) (interface{}, error) {
+			return asn.extractPublicKeyFromPayload(sri)
+		})
+		if err != nil {
+			return fmt.Errorf("parse signedRenewalInfo: %w", err)
+		}
+		asn.RenewalInfo = renewalInfo
 	}
-	asn.TransactionInfo = transactionInfo
 
-	// renewal info
-	renewalInfo := &RenewalInfo{}
-	payload = asn.Payload.Data.SignedRenewalInfo
-	_, err = jwt.ParseWithClaims(payload, renewalInfo, func(token *jwt.Token) (interface{}, error) {
-		return asn.extractPublicKeyFromPayload(payload)
-	})
-	if err != nil {
-		panic(err)
-	}
-	asn.RenewalInfo = renewalInfo
-
-	// valid request
 	asn.IsValid = true
+	return nil
 }

--- a/v2.go
+++ b/v2.go
@@ -13,12 +13,9 @@ import (
 )
 
 func New(payload string, appleRootCert string) (*AppStoreServerNotification, error) {
-	asn := &AppStoreServerNotification{}
-	asn.IsValid = false
-	asn.IsTest = false
-	asn.appleRootCert = appleRootCert
+	asn := &AppStoreServerNotification{appleRootCert: appleRootCert}
 	if err := asn.parseJwtSignedPayload(payload); err != nil {
-		return asn, err
+		return nil, err
 	}
 	return asn, nil
 }
@@ -61,7 +58,7 @@ func (asn *AppStoreServerNotification) verifyCertificate(certByte []byte, interm
 
 	interCert, err := x509.ParseCertificate(intermediateCert)
 	if err != nil {
-		return errors.New("intermediate certificate couldn't be parsed")
+		return fmt.Errorf("intermediate certificate: %w", err)
 	}
 	intermediate := x509.NewCertPool()
 	intermediate.AddCert(interCert)

--- a/v2_test.go
+++ b/v2_test.go
@@ -8,33 +8,61 @@ import (
 )
 
 func TestServerNotificationV2(t *testing.T) {
-	// {"signedPayload":"..."}
 	appStoreServerRequest := os.Getenv("APPLE_NOTIFICATION_REQUEST")
 	if appStoreServerRequest == "" {
-		panic("No valid AppStoreServerRequest")
+		t.Skip("APPLE_NOTIFICATION_REQUEST not set")
 	}
 	var request AppStoreServerRequest
-	err := json.Unmarshal([]byte(appStoreServerRequest), &request) // bind byte to header structure
-	if err != nil {
-		panic(err)
+	if err := json.Unmarshal([]byte(appStoreServerRequest), &request); err != nil {
+		t.Fatal(err)
 	}
 
-	// -----BEGIN CERTIFICATE----- ......
 	rootCert := os.Getenv("APPLE_CERT")
 	if rootCert == "" {
-		panic("Apple Root Cert not available")
+		t.Fatal("APPLE_CERT not set")
 	}
 
-	appStoreServerNotification := New(request.SignedPayload, rootCert)
-
-	if !appStoreServerNotification.IsValid {
+	asn, err := New(request.SignedPayload, rootCert)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if !asn.IsValid {
 		t.Error("Payload is not valid")
 	}
 
 	fmt.Printf(
 		"NotificationType: %s\nEnvironment: %s\nIsTest: %t\n",
-		appStoreServerNotification.Payload.NotificationType,
-		appStoreServerNotification.Payload.Data.Environment,
-		appStoreServerNotification.IsTest,
+		asn.Payload.NotificationType,
+		asn.Payload.Data.Environment,
+		asn.IsTest,
 	)
+}
+
+func TestMalformedPayloads(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"empty string", ""},
+		{"not a jwt", "garbage"},
+		{"two segments", "a.b"},
+		{"three segments no x5c", "eyJhbGciOiJFUzI1NiJ9.e30.sig"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("New panicked: %v", r)
+				}
+			}()
+			asn, err := New(tc.payload, "dummy-cert")
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+			if asn != nil && asn.IsValid {
+				t.Error("IsValid should be false on error")
+			}
+		})
+	}
 }


### PR DESCRIPTION
this mr addresses an #5 issue.

## TROUBLE
when Apple sends certain types of notifications to the app (like test pings or purchase confirmations that don't include subscription details), the server crashes instead of gracefully ignoring the unexpected format. 

this fix makes the server handle those cases without crashing.

## CHANGES
- New() now returns an error instead of panicking — callers decide what to do with bad input;
- parseJwtSignedPayload propagates errors up the call stack instead of crashing the process;
- extractHeaderByIndex guards against short/missing x5c chains before indexing into them;
- inner JWT parsing (signedTransactionInfo, signedRenewalInfo) is skipped when the fields are empty, covering all Apple notification types that legitimately omit them (TEST, EXTERNAL_PURCHASE_TOKEN, RENEWAL_EXTENDED, etc.);
- jwt.StandardClaims swapped for jwt.RegisteredClaims and the import path updated to golang-jwt/jwt/v5;
- go.mod bumped from the deprecated v3 to v5.3.1;
- tests updated to the new two-value return; new table-driven test verifies no panic on empty string, non-JWT, two-segment, and x5c-less inputs.
